### PR TITLE
Improve setup script package manager detection

### DIFF
--- a/setup_grub.sh
+++ b/setup_grub.sh
@@ -4,8 +4,15 @@ set -e
 # Install required packages
 if command -v pacman >/dev/null 2>&1; then
     sudo pacman -S --needed grub efibootmgr os-prober
+elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y grub efibootmgr os-prober
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y grub efibootmgr os-prober
+elif command -v zypper >/dev/null 2>&1; then
+    sudo zypper install -y grub efibootmgr os-prober
 else
-    echo "pacman not found. Please install grub, efibootmgr and os-prober manually." >&2
+    echo "No supported package manager found. Please install grub, efibootmgr and os-prober manually." >&2
 fi
 
 # Run os-prober if available


### PR DESCRIPTION
## Summary
- detect several common package managers
- install grub, efibootmgr and os-prober using the detected manager
- keep manual fallback when none found

## Testing
- `bash -n setup_grub.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ebff1b6988322ba2b4561c62523f1