### PR TITLE
Add themes directory and improve setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,31 @@
 # GRUB Loader Setup
 
-Use the setup script to install GRUB and configure a theme:
+Use the setup script to install GRUB and configure a theme. The script will
+automatically install required packages using your system's package manager
+(`pacman`, `apt`, or `dnf`):
 
 ```bash
 sudo ./setup_grub.sh
 ```
 
-The script installs required packages, lets you select a theme from the `themes/` directory and generates `grub.cfg` automatically.
+The script installs required packages, lets you select a theme from the
+`themes/` directory and generates `grub.cfg` automatically.
+
+## Themes
+
+Available themes are stored under the `themes/` directory:
+
+- `dark`
+- `light`
+
+You will be prompted to choose one of these themes when the script runs.
+
+## Usage
+
+Run the setup script with root privileges:
+
+```bash
+sudo ./setup_grub.sh
+```
+
+Follow the prompts to install packages and select a theme.

--- a/setup_grub.sh
+++ b/setup_grub.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
-# Install required packages
+# Install required packages using the available package manager
 if command -v pacman >/dev/null 2>&1; then
     sudo pacman -S --needed grub efibootmgr os-prober
+elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y grub-efi-amd64 efibootmgr os-prober
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y grub2-efi efibootmgr os-prober
 else
-    echo "pacman not found. Please install grub, efibootmgr and os-prober manually." >&2
+    echo "No supported package manager found. Please install grub, efibootmgr and os-prober manually." >&2
 fi
 
 # Run os-prober if available

--- a/themes/dark/theme.txt
+++ b/themes/dark/theme.txt
@@ -1,0 +1,1 @@
+title = "Dark Theme"

--- a/themes/light/theme.txt
+++ b/themes/light/theme.txt
@@ -1,0 +1,1 @@
+title = "Light Theme"


### PR DESCRIPTION
## Summary
- add sample `themes/` directory with `dark` and `light` themes
- support pacman, apt and dnf package managers in `setup_grub.sh`
- document new themes and usage in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ebff2b3308322aab2e92432ef8169